### PR TITLE
Fixed product dropown and pagination in combo page, Added UIs under Orders

### DIFF
--- a/lib/Api/marketplace_api.dart
+++ b/lib/Api/marketplace_api.dart
@@ -48,8 +48,20 @@ class MarketplaceApi {
     final response = await http.get(Uri.parse(baseUrl), headers: headers);
 
     if (response.statusCode == 200) {
-      final List<dynamic> marketplaceJson = jsonDecode(response.body);
-      return marketplaceJson.map((json) => Marketplace.fromJson(json)).toList();
+      // Decode the response as a Map (JSON object)
+      final Map<String, dynamic> responseJson = jsonDecode(response.body);
+
+      // Access the 'marketplaces' list within the 'data' field
+      if (responseJson.containsKey('data') &&
+          responseJson['data'].containsKey('marketplaces')) {
+        final List<dynamic> marketplaceJson =
+            responseJson['data']['marketplaces'];
+        return marketplaceJson
+            .map((json) => Marketplace.fromJson(json))
+            .toList();
+      } else {
+        throw Exception('Expected "marketplaces" field not found in response');
+      }
     } else {
       throw Exception('Failed to load marketplaces: ${response.body}');
     }

--- a/lib/checker_page.dart
+++ b/lib/checker_page.dart
@@ -1,0 +1,341 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:inventory_management/Custom-Files/colors.dart';
+import 'package:inventory_management/provider/checker_provider.dart';
+
+class CheckerPage extends StatefulWidget {
+  const CheckerPage({super.key});
+
+  @override
+  State<CheckerPage> createState() => _CheckerPageState();
+}
+
+class _CheckerPageState extends State<CheckerPage> {
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<CheckerProvider>(
+      builder: (context, checkerProvider, child) {
+        // Fixed variable name to pickerProvider
+        return Scaffold(
+          body: Column(
+            children: [
+              // Display number of selected products
+              Padding(
+                padding: const EdgeInsets.all(8.0),
+                child: Text(
+                  'Selected Orders: ${checkerProvider.selectedCount}',
+                  style: const TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ),
+
+              // Table with horizontal scroll
+              Expanded(
+                child: Container(
+                  color: AppColors.greyBackground,
+                  width: double
+                      .infinity, // Make the table take the full width of the screen
+                  padding: const EdgeInsets.symmetric(
+                      horizontal: 16.0), // Optional padding
+
+                  child: SingleChildScrollView(
+                    scrollDirection: Axis.horizontal,
+                    child: SingleChildScrollView(
+                      child: DataTable(
+                        dataRowHeight: 300,
+                        columnSpacing: MediaQuery.of(context).size.width * 0.08,
+                        columns: [
+                          const DataColumn(
+                            label: Text(
+                              'ORDERS',
+                              style: TextStyle(
+                                fontSize: 18,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                          ),
+                          const DataColumn(
+                            label: Text(
+                              'CUSTOMER DETAIL',
+                              style: TextStyle(
+                                fontSize: 18,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                          ),
+                          const DataColumn(
+                            label: Text(
+                              'DATE',
+                              style: TextStyle(
+                                fontSize: 18,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                          ),
+                          const DataColumn(
+                            label: Text(
+                              'TOTAL',
+                              style: TextStyle(
+                                fontSize: 18,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                          ),
+                          const DataColumn(
+                            label: Text(
+                              'WEIGHT',
+                              style: TextStyle(
+                                fontSize: 18,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                          ),
+                          // DataColumn with checkbox to select/deselect all products
+                          DataColumn(
+                            label: Row(
+                              children: [
+                                Transform.scale(
+                                  scale: 1,
+                                  child: Checkbox(
+                                    value: checkerProvider.selectAll,
+                                    onChanged: (bool? value) {
+                                      checkerProvider
+                                          .toggleSelectAll(value ?? false);
+                                    },
+                                    activeColor: Colors
+                                        .blue, // Customize the active color
+                                    checkColor: Colors
+                                        .white, // Customize the check mark color
+                                    side: const BorderSide(
+                                        color: Colors
+                                            .blue), // Customize the border color
+                                    shape: RoundedRectangleBorder(
+                                      borderRadius: BorderRadius.circular(
+                                          4), // Customize the border radius
+                                    ),
+                                  ),
+                                ),
+                                const Text('Select All'),
+                              ],
+                            ),
+                          ),
+                        ],
+                        rows: List<DataRow>.generate(
+                          checkerProvider.selectedProducts.length,
+                          (index) => DataRow(
+                            selected: checkerProvider.selectedProducts[index],
+                            cells: [
+                              // Product Image and Name in one cell
+                              DataCell(
+                                SizedBox(
+                                  width: 556,
+                                  child: Padding(
+                                    padding: const EdgeInsets.all(4.0),
+                                    child: Column(
+                                      crossAxisAlignment:
+                                          CrossAxisAlignment.start,
+                                      children: [
+                                        // Display the Order ID
+                                        Text(
+                                          'ORDER ID: KSK-2599${index + 1}',
+                                          style: const TextStyle(
+                                              fontWeight: FontWeight.bold,
+                                              fontSize: 20,
+                                              color: Colors.blue),
+                                        ),
+
+                                        const SizedBox(height: 10),
+
+                                        const Row(
+                                          crossAxisAlignment:
+                                              CrossAxisAlignment.start,
+                                          children: [
+                                            SizedBox(width: 10),
+                                            SizedBox(
+                                              width: 430,
+                                              child: Column(
+                                                children: [
+                                                  // Product 1 Information
+                                                  Text(
+                                                    'Nemotude Plus (Bio Pesticides verticillium chalamydosporium 1% WP)',
+                                                    style:
+                                                        TextStyle(fontSize: 16),
+                                                    softWrap:
+                                                        true, // Enable text wrapping
+                                                    maxLines:
+                                                        3, // Adjust max lines if needed
+                                                    overflow:
+                                                        TextOverflow.ellipsis,
+                                                  ),
+                                                  SizedBox(height: 4),
+
+                                                  Row(
+                                                    children: [
+                                                      Text(
+                                                        'SKU : k-5560 ',
+                                                        style: TextStyle(
+                                                            fontSize: 14,
+                                                            fontWeight:
+                                                                FontWeight
+                                                                    .bold),
+                                                      ),
+                                                      SizedBox(width: 150),
+                                                      Text(
+                                                        'Quality : 10 ',
+                                                        style: TextStyle(
+                                                            fontSize: 14,
+                                                            fontWeight:
+                                                                FontWeight
+                                                                    .bold),
+                                                      ),
+                                                    ],
+                                                  ),
+                                                  SizedBox(height: 10),
+                                                ],
+                                              ),
+                                            ),
+                                          ],
+                                        ),
+                                        const Divider(color: Colors.grey),
+                                        const Row(
+                                          children: [
+                                            SizedBox(width: 10),
+                                            SizedBox(
+                                              width: 430,
+                                              child: Column(
+                                                children: [
+                                                  // Product 1 Information
+                                                  Text(
+                                                    'Motude Plus (Bio Pesticides verticillium chalamydosporium 1% WP)',
+                                                    style:
+                                                        TextStyle(fontSize: 16),
+                                                    softWrap:
+                                                        true, // Enable text wrapping
+                                                    maxLines:
+                                                        3, // Adjust max lines if needed
+                                                    overflow:
+                                                        TextOverflow.ellipsis,
+                                                  ),
+                                                  SizedBox(height: 4),
+                                                  Row(
+                                                    children: [
+                                                      Text(
+                                                        'SKU : k-9560 ',
+                                                        style: TextStyle(
+                                                            fontSize: 14,
+                                                            fontWeight:
+                                                                FontWeight
+                                                                    .bold),
+                                                      ),
+                                                      SizedBox(width: 150),
+                                                      Text(
+                                                        'Quality : 04 ',
+                                                        style: TextStyle(
+                                                            fontSize: 14,
+                                                            fontWeight:
+                                                                FontWeight
+                                                                    .bold),
+                                                      ),
+                                                    ],
+                                                  ),
+                                                  SizedBox(height: 10),
+                                                ],
+                                              ),
+                                            ),
+                                          ],
+                                        ),
+                                      ],
+                                    ),
+                                  ),
+                                ),
+                              ),
+                              // Delivery price (INR)
+                              const DataCell(
+                                Column(
+                                  mainAxisAlignment: MainAxisAlignment.center,
+                                  children: [
+                                    Text(
+                                      'Deependra Singh',
+                                      style: TextStyle(fontSize: 18),
+                                      overflow: TextOverflow.visible,
+                                      softWrap: true,
+                                    ),
+                                    Text(
+                                      '8758568384',
+                                      style: TextStyle(fontSize: 18),
+                                      overflow: TextOverflow.visible,
+                                      softWrap: true,
+                                    ),
+                                  ],
+                                ),
+                              ),
+
+                              // Shiprocket price (INR)
+                              const DataCell(
+                                Text(
+                                  '12/02/2020',
+                                  style: TextStyle(fontSize: 18),
+                                  overflow: TextOverflow.visible,
+                                  softWrap: true,
+                                ),
+                              ),
+                              const DataCell(
+                                Text(
+                                  '\$1200',
+                                  style: TextStyle(fontSize: 18),
+                                  overflow: TextOverflow.visible,
+                                  softWrap: true,
+                                ),
+                              ),
+
+                              DataCell(
+                                Text(
+                                  'Weight ${index + 1}',
+                                  style: const TextStyle(fontSize: 18),
+                                  overflow: TextOverflow.visible,
+                                  softWrap: true,
+                                ),
+                              ),
+
+                              // Checkbox for each row
+                              DataCell(
+                                Transform.scale(
+                                  scale: 1,
+                                  child: Checkbox(
+                                    value:
+                                        checkerProvider.selectedProducts[index],
+                                    onChanged: (bool? value) {
+                                      checkerProvider.toggleProductSelection(
+                                          index, value ?? false);
+                                    },
+                                    activeColor: Colors
+                                        .blue, // Customize the active color
+                                    checkColor: Colors
+                                        .white, // Customize the check mark color
+                                    side: const BorderSide(
+                                        color: Colors
+                                            .blue), // Customize the border color
+                                    shape: RoundedRectangleBorder(
+                                      borderRadius: BorderRadius.circular(
+                                          4), // Customize the border radius
+                                    ),
+                                  ),
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/combo_page.dart
+++ b/lib/combo_page.dart
@@ -17,6 +17,9 @@ class ComboPage extends StatefulWidget {
 }
 
 class _ComboPageState extends State<ComboPage> {
+  int currentPage = 1;
+  int totalCombos = 0;
+
   Product? product;
   ComboProvider? comboProvider;
   final _idController = TextEditingController();
@@ -26,8 +29,9 @@ class _ComboPageState extends State<ComboPage> {
   final _costController = TextEditingController();
 
   //final productController = MultiSelectController<String>();
- 
+
   late final MultiSelectController<String> productController;
+  List<DropdownItem<String>> items = [];
 
   void _clearFormFields() {
     _idController.clear();
@@ -42,7 +46,6 @@ class _ComboPageState extends State<ComboPage> {
     ComboProvider comboProvider =
         Provider.of<ComboProvider>(context, listen: false);
 
-    // Get the selected product IDs directly from the dropdown's selections
     List<String?> selectedProductIds =
         comboProvider.selectedProducts.map((product) => product.id).toList();
 
@@ -73,32 +76,42 @@ class _ComboPageState extends State<ComboPage> {
   void initState() {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      comboProvider = Provider.of<ComboProvider>(context, listen: false);
-
+      final comboProvider = Provider.of<ComboProvider>(context, listen: false);
+      comboProvider.fetchCombos(page: currentPage, limit: 10);
+      //comboProvider.fetchProducts();
       productController = MultiSelectController<String>();
-      // print(1);
-      // print(object)
       getDropValue();
+      // print(1);
     });
   }
 
+  // Function to load more combos
+  void loadMoreCombos() async {
+    currentPage++;
+    final comboProvider = Provider.of<ComboProvider>(context, listen: false);
+    await comboProvider.fetchCombos(page: currentPage, limit: 10);
+  }
+
   void getDropValue() async {
-    await comboProvider!.fetchCombos();
-    await comboProvider!.fetchProducts();
-    print("new style");
-    for (int i = 0; i < comboProvider!.products.length; i++) {
-      print("heello i am divyansh");
-      comboProvider!.addItem('$i:${comboProvider!.products[i].displayName}', comboProvider!.products[i].id);
-      // items.add(DropdownItem<String>(
-      //   label: '$i:${comboProvider!.products[i].displayName}',
-      //   value: comboProvider!.products[i].id,
-      // ));
+    await Provider.of<ComboProvider>(context, listen: false).fetchProducts();
+    print("getDropValue");
+
+    List<DropdownItem<String>> newItems = [];
+    ComboProvider comboProvider =
+        Provider.of<ComboProvider>(context, listen: false);
+
+    for (int i = 0; i < comboProvider.products.length; i++) {
+      newItems.add(DropdownItem<String>(
+        label: '$i: ${comboProvider.products[i].displayName ?? 'Unknown'}',
+        value: comboProvider.products[i].id,
+      ));
     }
 
-    print("length of it is here ${comboProvider!.item.length}");
-    // setState(() {
-  
-    // });
+    //print("items in drop down: $newItems");
+
+    setState(() {
+      items = newItems;
+    });
   }
 
   @override
@@ -108,7 +121,9 @@ class _ComboPageState extends State<ComboPage> {
         padding: const EdgeInsets.all(16.0),
         child: Consumer<ComboProvider>(
           builder: (context, comboProvider, child) {
-            // print("hete i am $items");
+            if (comboProvider.products.isNotEmpty && items.isEmpty) {
+              getDropValue(); // Generate the dropdown items
+            }
 
             return Column(
               crossAxisAlignment: CrossAxisAlignment.start,
@@ -121,46 +136,45 @@ class _ComboPageState extends State<ComboPage> {
                 ),
                 if (comboProvider.isFormVisible) ...[
                   const SizedBox(height: 16),
-                  // TextField(
-                  //   controller: _idController,
-                  //   decoration: const InputDecoration(labelText: 'ID'),
-                  // ),
-                  const SizedBox(height: 16),
+
                   TextField(
                     controller: _nameController,
                     decoration: const InputDecoration(labelText: 'Name'),
                   ),
                   const SizedBox(height: 16),
-                  MultiDropdown<String>(
-                    items:comboProvider.item,
-                    controller: productController,
-                    searchEnabled: true,
-                    chipDecoration: const ChipDecoration(
-                      backgroundColor: Colors.yellow,
-                      wrap: true,
-                      runSpacing: 2,
-                      spacing: 10,
-                    ),
-                    fieldDecoration: FieldDecoration(
-                      hintText: 'Select Products',
-                      border: OutlineInputBorder(
-                        borderRadius: BorderRadius.circular(12),
-                        borderSide: const BorderSide(color: Colors.grey),
-                      ),
-                      focusedBorder: OutlineInputBorder(
-                        borderRadius: BorderRadius.circular(12),
-                        borderSide: const BorderSide(color: Colors.black87),
-                      ),
-                    ),
-                    dropdownDecoration: const DropdownDecoration(
-                      maxHeight: 500,
-                    ),
-                    onSelectionChange: (selectedItems) {
-                      debugPrint(
-                          'Selected items (product IDs): $selectedItems');
-                      comboProvider.selectProductsByIds(selectedItems);
-                    },
-                  ),
+                  items.isEmpty
+                      ? const CircularProgressIndicator() // Show loading if items are not ready
+                      : MultiDropdown<String>(
+                          items: items,
+                          controller: productController,
+                          searchEnabled: true,
+                          chipDecoration: const ChipDecoration(
+                            backgroundColor: Colors.yellow,
+                            wrap: true,
+                            runSpacing: 2,
+                            spacing: 10,
+                          ),
+                          fieldDecoration: FieldDecoration(
+                            hintText: 'Select Products',
+                            border: OutlineInputBorder(
+                              borderRadius: BorderRadius.circular(12),
+                              borderSide: const BorderSide(color: Colors.grey),
+                            ),
+                            focusedBorder: OutlineInputBorder(
+                              borderRadius: BorderRadius.circular(12),
+                              borderSide:
+                                  const BorderSide(color: Colors.black87),
+                            ),
+                          ),
+                          dropdownDecoration: const DropdownDecoration(
+                            maxHeight: 500,
+                          ),
+                          onSelectionChange: (selectedItems) {
+                            debugPrint(
+                                'Selected items (product IDs): $selectedItems');
+                            comboProvider.selectProductsByIds(selectedItems);
+                          },
+                        ),
 
                   const SizedBox(height: 16),
                   TextField(
@@ -244,7 +258,7 @@ class _ComboPageState extends State<ComboPage> {
                   const Text(
                     'Existing Combos:',
                     style: TextStyle(
-                      fontSize: 22,
+                      fontSize: 24,
                       fontWeight: FontWeight.bold,
                       color: Colors.black87,
                     ),
@@ -259,51 +273,119 @@ class _ComboPageState extends State<ComboPage> {
                         itemCount: comboProvider.combosList.length,
                         itemBuilder: (context, index) {
                           final combo = comboProvider.combosList[index];
+                          final images =
+                              combo['images'] as List<dynamic>? ?? [];
                           final products =
-                              (combo['products'] as List<dynamic>?) ?? [];
+                              combo['products'] as List<dynamic>? ?? [];
+
                           return Card(
-                            margin: const EdgeInsets.symmetric(vertical: 8),
+                            elevation: 4,
+                            shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(15),
+                            ),
+                            margin: const EdgeInsets.symmetric(
+                                vertical: 12, horizontal: 16),
                             child: Padding(
                               padding: const EdgeInsets.all(16.0),
                               child: Column(
                                 crossAxisAlignment: CrossAxisAlignment.start,
                                 children: [
-                                  Text('Name: ${combo['name'] ?? 'N/A'}'),
-                                  Text('MRP: ${combo['mrp'] ?? 'N/A'}'),
-                                  Text('Cost: ${combo['cost'] ?? 'N/A'}'),
-                                  Text('SKU: ${combo['sku'] ?? 'N/A'}'),
-                                  if (products.isNotEmpty) ...[
+                                  Row(
+                                    children: [
+                                      Text(
+                                        combo['name'] ?? 'N/A',
+                                        style: const TextStyle(
+                                          fontSize: 20,
+                                          fontWeight: FontWeight.bold,
+                                          color: Colors.black87,
+                                        ),
+                                      ),
+                                    ],
+                                  ),
+                                  const SizedBox(height: 8),
+                                  Text(
+                                    'MRP: ₹${combo['mrp'] ?? 'N/A'}',
+                                    style: TextStyle(
+                                        fontSize: 16, color: Colors.grey[700]),
+                                  ),
+                                  Text(
+                                    'Cost: ₹${combo['cost'] ?? 'N/A'}',
+                                    style: TextStyle(
+                                        fontSize: 16, color: Colors.grey[700]),
+                                  ),
+                                  Text(
+                                    'SKU: ${combo['comboSku'] ?? 'N/A'}',
+                                    style: TextStyle(
+                                        fontSize: 16, color: Colors.grey[700]),
+                                  ),
+                                  const SizedBox(height: 16),
+                                  if (images.isNotEmpty) ...[
+                                    const Text(
+                                      'Images:',
+                                      style: TextStyle(
+                                        fontSize: 18,
+                                        fontWeight: FontWeight.bold,
+                                        color: Colors.black87,
+                                      ),
+                                    ),
                                     const SizedBox(height: 8),
-                                    const Text('Products:'),
+                                    SingleChildScrollView(
+                                      scrollDirection: Axis.horizontal,
+                                      child: Row(
+                                        children: images.map((imageUrl) {
+                                          return Padding(
+                                            padding: const EdgeInsets.only(
+                                                right: 8.0),
+                                            child: ClipRRect(
+                                              borderRadius:
+                                                  BorderRadius.circular(8.0),
+                                              child: Image.network(
+                                                imageUrl,
+                                                width: 100,
+                                                height: 100,
+                                                fit: BoxFit.cover,
+                                              ),
+                                            ),
+                                          );
+                                        }).toList(),
+                                      ),
+                                    ),
+                                  ],
+                                  if (products.isNotEmpty) ...[
+                                    const Text(
+                                      'Products:',
+                                      style: TextStyle(
+                                        fontSize: 18,
+                                        fontWeight: FontWeight.bold,
+                                        color: Colors.black87,
+                                      ),
+                                    ),
+                                    const SizedBox(height: 8),
                                     Column(
                                       children: products.map((product) {
-                                        // Ensure that 'image' field exists and is a list of URLs.
-                                        final imageUrl = (product['images']
-                                                        as List<dynamic>?)
-                                                    ?.isNotEmpty ==
-                                                true
-                                            ? product['images'][0]
-                                            : null;
-
                                         return ListTile(
-                                          leading: imageUrl != null
-                                              ? Image.network(
-                                                  imageUrl,
-                                                  width: 50,
-                                                  height: 50,
-                                                  fit: BoxFit.cover,
-                                                )
-                                              : const Icon(
-                                                  Icons.image,
-                                                  size: 50,
-                                                  color: Colors.grey,
-                                                ),
                                           title: Text(
-                                              product['displayName'] ?? 'N/A'),
+                                            product['displayName']
+                                                    ?.toString() ??
+                                                'No Name Available',
+                                            style: const TextStyle(
+                                                fontSize: 16,
+                                                fontWeight: FontWeight.w500),
+                                          ),
                                           subtitle: Text(
-                                              'SKU: ${product['sku'] ?? 'N/A'}'),
+                                            'SKU: ${product['sku']?.toString() ?? 'No SKU Available'}',
+                                            style: TextStyle(
+                                                fontSize: 14,
+                                                color: Colors.grey[600]),
+                                          ),
                                         );
                                       }).toList(),
+                                    ),
+                                  ] else ...[
+                                    const Text(
+                                      'No products available for this combo.',
+                                      style: TextStyle(
+                                          fontSize: 16, color: Colors.grey),
                                     ),
                                   ],
                                 ],
@@ -312,8 +394,48 @@ class _ComboPageState extends State<ComboPage> {
                           );
                         },
                       ),
+                    )
+                  else if (!comboProvider.loading &&
+                      comboProvider.combosList.isEmpty) ...[
+                    const Text(
+                      'No combos available.',
+                      style: TextStyle(fontSize: 16, color: Colors.grey),
                     ),
-                ],
+                  ],
+                  // Pagination Controls
+                  if (!comboProvider.loading &&
+                      comboProvider.combosList.isNotEmpty) ...[
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                        Padding(
+                          padding: const EdgeInsets.all(10),
+                          child: ElevatedButton(
+                            onPressed: currentPage > 1
+                                ? () {
+                                    setState(() {
+                                      currentPage--;
+                                    });
+                                    loadMoreCombos();
+                                  }
+                                : null,
+                            child: const Text('Previous'),
+                          ),
+                        ),
+                        Text('Page $currentPage'),
+                        Padding(
+                          padding: const EdgeInsets.all(8),
+                          child: ElevatedButton(
+                            onPressed: () {
+                              loadMoreCombos();
+                            },
+                            child: const Text('Next'),
+                          ),
+                        ),
+                      ],
+                    )
+                  ],
+                ]
 
                 // Do not touch this code - End
               ],
@@ -321,30 +443,14 @@ class _ComboPageState extends State<ComboPage> {
           },
         ),
       ),
+      // floatingActionButton: FloatingActionButton(
+      //   onPressed: () {
+      //     Provider.of<ComboProvider>(context, listen: false).fetchCombos();
+      //   },
+      //   backgroundColor: Colors.blue,
+      //   tooltip: 'Fetch Combos',
+      //   child: const Icon(Icons.refresh),
+      // ),
     );
   }
-}
-
-class CustomDropdownItem<T> extends DropdownItem<T> {
-  CustomDropdownItem({
-    required String label,
-    required T value,
-    bool disabled = false,
-    bool selected = false,
-  }) : super(
-          label: label,
-          value: value,
-          disabled: disabled,
-          selected: selected,
-        );
-
-  @override
-  bool operator ==(Object other) {
-    if (identical(this, other)) return true;
-
-    return other is CustomDropdownItem<T> && other.value == value;
-  }
-
-  @override
-  int get hashCode => value.hashCode;
 }

--- a/lib/dashboard.dart
+++ b/lib/dashboard.dart
@@ -2,16 +2,22 @@ import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:intl/intl.dart';
 import 'package:inventory_management/book_page.dart';
+import 'package:inventory_management/checker_page.dart';
 import 'package:inventory_management/combo_page.dart';
 import 'package:inventory_management/create-label-page.dart';
 import 'package:inventory_management/location_master.dart';
 import 'package:inventory_management/manage-inventory.dart';
+import 'package:inventory_management/manifest_page.dart';
 import 'package:inventory_management/marketplace_page.dart';
 import 'package:inventory_management/order-page.dart';
+import 'package:inventory_management/packer_page.dart';
+import 'package:inventory_management/picker_page.dart';
+import 'package:inventory_management/orders_page.dart';
 
 import 'package:inventory_management/products.dart';
 import 'package:inventory_management/category_master.dart';
 import 'package:inventory_management/dashboard_cards.dart';
+import 'package:inventory_management/racked_page.dart';
 import 'package:inventory_management/show-label-page.dart';
 import 'Custom-Files/colors.dart';
 import 'package:inventory_management/product_manager.dart';
@@ -25,7 +31,6 @@ class DashboardPage extends StatefulWidget {
 }
 
 class _DashboardPageState extends State<DashboardPage> {
-
   String selectedDrawerItem = 'Dashboard';
 
   DateTime? lastUpdatedTime;
@@ -156,37 +161,37 @@ class _DashboardPageState extends State<DashboardPage> {
       children: <Widget>[
         Expanded(
           child: SingleChildScrollView(
-            scrollDirection:Axis.vertical,
+            scrollDirection: Axis.vertical,
             child: Column(
               children: [
                 const SizedBox(height: 20),
-                      const Padding(
-            padding: EdgeInsets.all(20.0),
-            child: Text(
-              'Katyayani',
-              style: TextStyle(
-                fontSize: 27,
-                fontWeight: FontWeight.bold,
-                color: AppColors.primaryBlue,
-              ),
-            ),
-                      ),
-                      const SizedBox(height: 20),
-                      _buildDrawerItem(
-            icon: Icons.dashboard,
-            text: 'Dashboard',
-            isSelected: selectedDrawerItem == 'Dashboard',
-            onTap: () => _onDrawerItemTapped('Dashboard', isSmallScreen),
-                      ),
-                      _buildOrdersSection(isSmallScreen),
-                      _buildInventorySection(isSmallScreen),
-                      _buildMasterSection(isSmallScreen),
-                      _buildDrawerItem(
-            icon: Icons.analytics,
-            text: 'Accounting',
-            isSelected: selectedDrawerItem == 'Accounting',
-            onTap: () => _onDrawerItemTapped('Accounting', isSmallScreen),
-                      ),
+                const Padding(
+                  padding: EdgeInsets.all(20.0),
+                  child: Text(
+                    'Katyayani',
+                    style: TextStyle(
+                      fontSize: 27,
+                      fontWeight: FontWeight.bold,
+                      color: AppColors.primaryBlue,
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 20),
+                _buildDrawerItem(
+                  icon: Icons.dashboard,
+                  text: 'Dashboard',
+                  isSelected: selectedDrawerItem == 'Dashboard',
+                  onTap: () => _onDrawerItemTapped('Dashboard', isSmallScreen),
+                ),
+                _buildOrdersSection(isSmallScreen),
+                _buildInventorySection(isSmallScreen),
+                _buildMasterSection(isSmallScreen),
+                _buildDrawerItem(
+                  icon: Icons.analytics,
+                  text: 'Accounting',
+                  isSelected: selectedDrawerItem == 'Accounting',
+                  onTap: () => _onDrawerItemTapped('Accounting', isSmallScreen),
+                ),
               ],
             ),
           ),
@@ -215,7 +220,7 @@ class _DashboardPageState extends State<DashboardPage> {
     );
   }
 
-    Widget _buildOrdersSection(bool isSmallScreen) {
+  Widget _buildOrdersSection(bool isSmallScreen) {
     return Theme(
       data: ThemeData(
         dividerColor: Colors.transparent,
@@ -244,13 +249,25 @@ class _DashboardPageState extends State<DashboardPage> {
             ? const Color.fromRGBO(6, 90, 216, 0.1)
             : null,
         children: <Widget>[
-           Padding(
+          Padding(
             padding: const EdgeInsets.only(left: 10.0),
             child: _buildDrawerItem(
               icon: Icons.menu_book,
               text: 'Order Page',
               isSelected: selectedDrawerItem == 'Order Page',
               onTap: () => _onDrawerItemTapped('Order Page', isSmallScreen),
+              isIndented: true,
+              iconSize: 20,
+              fontSize: 14,
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.only(left: 10.0),
+            child: _buildDrawerItem(
+              icon: Icons.assignment_rounded,
+              text: 'Orders',
+              isSelected: selectedDrawerItem == 'Orders Page',
+              onTap: () => _onDrawerItemTapped('Orders Page', isSmallScreen),
               isIndented: true,
               iconSize: 20,
               fontSize: 14,
@@ -276,9 +293,8 @@ class _DashboardPageState extends State<DashboardPage> {
             child: _buildDrawerItem(
               icon: Icons.local_shipping,
               text: 'Picker',
-              isSelected: selectedDrawerItem == 'Picker',
-              onTap: () =>
-                  _onDrawerItemTapped('Picker', isSmallScreen),
+              isSelected: selectedDrawerItem == 'Picker Page',
+              onTap: () => _onDrawerItemTapped('Picker Page', isSmallScreen),
               isIndented: true,
               iconSize: 20,
               fontSize: 14,
@@ -289,8 +305,8 @@ class _DashboardPageState extends State<DashboardPage> {
             child: _buildDrawerItem(
               icon: Icons.backpack_rounded,
               text: 'Packer',
-              isSelected: selectedDrawerItem == 'Packer',
-              onTap: () => _onDrawerItemTapped('Packer', isSmallScreen),
+              isSelected: selectedDrawerItem == 'Packer Page',
+              onTap: () => _onDrawerItemTapped('Packer Page', isSmallScreen),
               isIndented: true,
               iconSize: 20,
               fontSize: 14,
@@ -301,20 +317,32 @@ class _DashboardPageState extends State<DashboardPage> {
             child: _buildDrawerItem(
               icon: Icons.check_circle,
               text: 'Checker',
-              isSelected: selectedDrawerItem == 'Checker',
-              onTap: () => _onDrawerItemTapped('Checker', isSmallScreen),
+              isSelected: selectedDrawerItem == 'Checker Page',
+              onTap: () => _onDrawerItemTapped('Checker Page', isSmallScreen),
               isIndented: true,
               iconSize: 20,
               fontSize: 14,
             ),
           ),
-            Padding(
+          Padding(
             padding: const EdgeInsets.only(left: 10.0),
             child: _buildDrawerItem(
               icon: Icons.shelves,
               text: 'Racked',
-              isSelected: selectedDrawerItem == 'Racked',
-              onTap: () => _onDrawerItemTapped('Racked', isSmallScreen),
+              isSelected: selectedDrawerItem == 'Racked Page',
+              onTap: () => _onDrawerItemTapped('Racked Page', isSmallScreen),
+              isIndented: true,
+              iconSize: 20,
+              fontSize: 14,
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.only(left: 10.0),
+            child: _buildDrawerItem(
+              icon: Icons.star_border,
+              text: 'Manifest',
+              isSelected: selectedDrawerItem == 'Manifest Page',
+              onTap: () => _onDrawerItemTapped('Manifest Page', isSmallScreen),
               isIndented: true,
               iconSize: 20,
               fontSize: 14,
@@ -421,7 +449,8 @@ class _DashboardPageState extends State<DashboardPage> {
               icon: Icons.production_quantity_limits,
               text: 'Create Label Page',
               isSelected: selectedDrawerItem == 'Create Label Page',
-              onTap: () => _onDrawerItemTapped('Create Label Page', isSmallScreen),
+              onTap: () =>
+                  _onDrawerItemTapped('Create Label Page', isSmallScreen),
               isIndented: true,
               iconSize: 20,
               fontSize: 14,
@@ -474,7 +503,8 @@ class _DashboardPageState extends State<DashboardPage> {
               icon: Icons.add_business,
               text: 'Marketplace Master',
               isSelected: selectedDrawerItem == 'Marketplace Master',
-              onTap: () => _onDrawerItemTapped('Marketplace Master', isSmallScreen),
+              onTap: () =>
+                  _onDrawerItemTapped('Marketplace Master', isSmallScreen),
               isIndented: true,
               iconSize: 20,
               fontSize: 14,
@@ -555,7 +585,7 @@ class _DashboardPageState extends State<DashboardPage> {
   Widget _buildMainContent(String selectedDrawerItem, bool isSmallScreen) {
     switch (selectedDrawerItem) {
       case 'Dashboard':
-      // return Products();
+        // return Products();
         return _buildDashboardContent(isSmallScreen);
       case 'Sales Orders':
         return const Center(child: Text("Sales Orders content goes here"));
@@ -567,11 +597,23 @@ class _DashboardPageState extends State<DashboardPage> {
         return const ManageInventory();
       case 'Order Page':
         return const OrdersPage();
+      case 'Orders Page':
+        return const OrdersNewPage();
       case 'Book Page':
         return const BookPage();
+      case 'Picker Page':
+        return const PickerPage();
+      case 'Packer Page':
+        return const PackerPage();
+      case 'Checker Page':
+        return const CheckerPage();
+      case 'Racked Page':
+        return const RackedPage();
+      case 'Manifest Page':
+        return const ManifestPage();
       case 'Product Master':
         return const ProductDashboardPage();
-       case 'Create Label Page':
+      case 'Create Label Page':
         return const CreateLabelPage();
       case 'Label Page':
         return const LabelPage();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -18,27 +18,41 @@ import 'package:inventory_management/login_page.dart';
 import 'package:inventory_management/products.dart';
 import 'package:inventory_management/provider/category_provider.dart';
 import 'package:inventory_management/provider/combo_provider.dart';
+import 'package:inventory_management/provider/orders_provider.dart';
+import 'package:inventory_management/provider/picker_provider.dart';
+import 'package:inventory_management/provider/packer_provider.dart';
+import 'package:inventory_management/provider/checker_provider.dart';
+import 'package:inventory_management/provider/racked_provider.dart';
+import 'package:inventory_management/provider/manifest_provider.dart';
+import 'package:inventory_management/provider/checker_provider.dart';
 import 'package:inventory_management/provider/location_provider.dart';
 import 'package:inventory_management/provider/manage-inventory-provider.dart';
 import 'package:inventory_management/show-label-page.dart';
 
 import 'package:provider/provider.dart';
+
 // import 'package:inventory_management/create_account.dart';
 // prarthi2474@gmail.com
 void main() {
   WidgetsFlutterBinding.ensureInitialized();
   runApp(MultiProvider(
     providers: [
-      ChangeNotifierProvider(create:(context)=>LabelApi()),
+      ChangeNotifierProvider(create: (context) => LabelApi()),
       ChangeNotifierProvider(create: (context) => AuthProvider()),
       ChangeNotifierProvider(create: (context) => CheckBoxProvider()),
       ChangeNotifierProvider(create: (context) => ManagementProvider()),
-      
-      ChangeNotifierProvider(create: (context)=>LabelPageApi()),
+
+      ChangeNotifierProvider(create: (context) => LabelPageApi()),
       ChangeNotifierProvider(create: (context) => MarketplaceProvider()),
       ChangeNotifierProvider(create: (context) => BookProvider()),
       ChangeNotifierProvider(create: (context) => ProductProvider()),
       ChangeNotifierProvider(create: (context) => ComboProvider()),
+      ChangeNotifierProvider(create: (context) => PickerProvider()),
+      ChangeNotifierProvider(create: (context) => PackerProvider()),
+      ChangeNotifierProvider(create: (context) => CheckerProvider()),
+      ChangeNotifierProvider(create: (context) => ManifestProvider()),
+      ChangeNotifierProvider(create: (context) => RackedProvider()),
+      ChangeNotifierProvider(create: (context) => OrdersProvider()),
       // ChangeNotifierProvider(create: (context) => CheckBoxProvider()),
       ChangeNotifierProvider(
         create: (context) => LocationProvider(
@@ -71,9 +85,7 @@ class MyApp extends StatelessWidget {
           ),
         ),
       ),
-
-      home:Home(),
-
+      home: Home(),
     );
   }
 }
@@ -86,13 +98,14 @@ class Home extends StatefulWidget {
 }
 
 class _HomeState extends State<Home> {
- AuthProvider? authprovider;
+  AuthProvider? authprovider;
   @override
   void initState() {
     // TODO: implement initState
     super.initState();
     // getData();
   }
+
   // void getData()async{
   //    authprovider=Provider.of<AuthProvider>(context,listen:true);
   //    await authprovider!.getToken();
@@ -100,24 +113,23 @@ class _HomeState extends State<Home> {
   @override
   Widget build(BuildContext context) {
     // var prov=Provider.of<AuthProvider>(context,listen:true);
-     
+
     return Consumer<AuthProvider>(
-      builder:(context,authprovider, child)=>FutureBuilder<String?>(
-        future:authprovider.getToken(),
-         builder:(context,snap){
-          if(snap.connectionState==ConnectionState.waiting){
-            return const CircularProgressIndicator();
-          }else if(snap.hasData){
-            if(authprovider.isAuthenticated){
-              return const DashboardPage();
-            }else{
+      builder: (context, authprovider, child) => FutureBuilder<String?>(
+          future: authprovider.getToken(),
+          builder: (context, snap) {
+            if (snap.connectionState == ConnectionState.waiting) {
+              return const CircularProgressIndicator();
+            } else if (snap.hasData) {
+              if (authprovider.isAuthenticated) {
+                return const DashboardPage();
+              } else {
+                return const LoginPage();
+              }
+            } else {
               return const LoginPage();
             }
-          }else {
-            return const LoginPage();
-          }
-         } 
-         ),
+          }),
       // home: const LoginPage(),
       // routes: {
       //   '/login': (context) => const LoginPage(),

--- a/lib/manifest_page.dart
+++ b/lib/manifest_page.dart
@@ -1,0 +1,219 @@
+import 'package:flutter/material.dart';
+import 'package:inventory_management/Custom-Files/colors.dart';
+import 'package:inventory_management/provider/manifest_provider.dart';
+import 'package:provider/provider.dart';
+
+class ManifestPage extends StatefulWidget {
+  const ManifestPage({super.key});
+
+  @override
+  _ManifestPageState createState() => _ManifestPageState();
+}
+
+class _ManifestPageState extends State<ManifestPage> {
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<ManifestProvider>(
+      builder: (context, manifestProvider, child) {
+        return Scaffold(
+          body: Column(
+            children: [
+              // Table with horizontal scroll
+              Expanded(
+                child: Container(
+                  color: AppColors.greyBackground,
+                  width: double
+                      .infinity, // Make the table take the full width of the screen
+                  padding: const EdgeInsets.symmetric(
+                      horizontal: 16.0), // Optional padding
+
+                  child: SingleChildScrollView(
+                    scrollDirection: Axis.horizontal,
+                    child: SingleChildScrollView(
+                      child: DataTable(
+                        dataRowHeight: 300,
+                        columnSpacing: MediaQuery.of(context).size.width * 0.2,
+                        columns: const [
+                          DataColumn(
+                            label: Text(
+                              'PRODUCTS',
+                              style: TextStyle(
+                                fontSize: 18,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                          ),
+                          DataColumn(
+                            label: Text(
+                              'DELIVERY PARTNER SIGNATURE',
+                              style: TextStyle(
+                                fontSize: 18,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                          ),
+                        ],
+                        rows: List<DataRow>.generate(
+                          manifestProvider.selectedProducts.length,
+                          (index) => DataRow(
+                            selected: manifestProvider.selectedProducts[index],
+                            cells: [
+                              // Product Image and Name in one cell
+                              DataCell(
+                                SizedBox(
+                                  width: 556,
+                                  child: Padding(
+                                    padding: const EdgeInsets.all(4.0),
+                                    child: Column(
+                                      crossAxisAlignment:
+                                          CrossAxisAlignment.start,
+                                      children: [
+                                        // Display the Order ID
+                                        Text(
+                                          'ORDER ID: KSK-2599${index + 1}',
+                                          style: const TextStyle(
+                                              fontWeight: FontWeight.bold,
+                                              fontSize: 20,
+                                              color: Colors.blue),
+                                        ),
+
+                                        const SizedBox(height: 10),
+
+                                        const Row(
+                                          crossAxisAlignment:
+                                              CrossAxisAlignment.start,
+                                          children: [
+                                            SizedBox(width: 10),
+                                            SizedBox(
+                                              width: 430,
+                                              child: Column(
+                                                children: [
+                                                  // Product 1 Information
+                                                  Text(
+                                                    'Nemotude Plus (Bio Pesticides verticillium chalamydosporium 1% WP)',
+                                                    style:
+                                                        TextStyle(fontSize: 16),
+                                                    softWrap:
+                                                        true, // Enable text wrapping
+                                                    maxLines:
+                                                        3, // Adjust max lines if needed
+                                                    overflow:
+                                                        TextOverflow.ellipsis,
+                                                  ),
+                                                  SizedBox(height: 4),
+
+                                                  Row(
+                                                    children: [
+                                                      Text(
+                                                        'SKU : k-5560 ',
+                                                        style: TextStyle(
+                                                            fontSize: 14,
+                                                            fontWeight:
+                                                                FontWeight
+                                                                    .bold),
+                                                      ),
+                                                      SizedBox(width: 150),
+                                                      Text(
+                                                        'Quality : 10 ',
+                                                        style: TextStyle(
+                                                            fontSize: 14,
+                                                            fontWeight:
+                                                                FontWeight
+                                                                    .bold),
+                                                      ),
+                                                    ],
+                                                  ),
+                                                  SizedBox(height: 10),
+                                                ],
+                                              ),
+                                            ),
+                                          ],
+                                        ),
+                                        const Divider(color: Colors.grey),
+                                        const Row(
+                                          children: [
+                                            SizedBox(width: 10),
+                                            SizedBox(
+                                              width: 430,
+                                              child: Column(
+                                                children: [
+                                                  // Product 1 Information
+                                                  Text(
+                                                    'Motude Plus (Bio Pesticides verticillium chalamydosporium 1% WP)',
+                                                    style:
+                                                        TextStyle(fontSize: 16),
+                                                    softWrap:
+                                                        true, // Enable text wrapping
+                                                    maxLines:
+                                                        3, // Adjust max lines if needed
+                                                    overflow:
+                                                        TextOverflow.ellipsis,
+                                                  ),
+                                                  SizedBox(height: 4),
+                                                  Row(
+                                                    children: [
+                                                      Text(
+                                                        'SKU : k-9560 ',
+                                                        style: TextStyle(
+                                                            fontSize: 14,
+                                                            fontWeight:
+                                                                FontWeight
+                                                                    .bold),
+                                                      ),
+                                                      SizedBox(width: 150),
+                                                      Text(
+                                                        'Quality : 04 ',
+                                                        style: TextStyle(
+                                                            fontSize: 14,
+                                                            fontWeight:
+                                                                FontWeight
+                                                                    .bold),
+                                                      ),
+                                                    ],
+                                                  ),
+                                                  SizedBox(height: 10),
+                                                ],
+                                              ),
+                                            ),
+                                          ],
+                                        ),
+                                      ],
+                                    ),
+                                  ),
+                                ),
+                              ),
+                              // Delivery price (INR)
+                              const DataCell(
+                                Column(
+                                  children: [
+                                    Icon(
+                                      Icons.image,
+                                      size: 130,
+                                      color: Colors.grey,
+                                    ),
+                                    SizedBox(
+                                      width: 24,
+                                    ),
+                                    Icon(
+                                      Icons.image,
+                                      size: 130,
+                                      color: Colors.grey,
+                                    ),
+                                  ],
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/marketplace_page.dart
+++ b/lib/marketplace_page.dart
@@ -151,7 +151,7 @@ class _MarketplacePageState extends State<MarketplacePage> {
             const Text(
               'Existing Marketplaces:',
               style: TextStyle(
-                fontSize: 22,
+                fontSize: 24,
                 fontWeight: FontWeight.bold,
                 color: Colors.black87,
               ),
@@ -175,13 +175,18 @@ class _MarketplacePageState extends State<MarketplacePage> {
 
                       return Card(
                         margin: const EdgeInsets.symmetric(
-                            vertical: 8, horizontal: 16),
-                        elevation: 4,
+                            vertical: 12, horizontal: 16),
+                        elevation:
+                            6, // Enhanced shadow for better card visibility
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(15),
+                        ),
                         child: Padding(
                           padding: const EdgeInsets.all(16.0),
                           child: Column(
                             crossAxisAlignment: CrossAxisAlignment.start,
                             children: [
+                              // Marketplace title with delete option
                               Row(
                                 mainAxisAlignment:
                                     MainAxisAlignment.spaceBetween,
@@ -189,13 +194,16 @@ class _MarketplacePageState extends State<MarketplacePage> {
                                   Text(
                                     marketplace.name,
                                     style: const TextStyle(
-                                        fontSize: 18,
-                                        fontWeight: FontWeight.bold),
+                                      fontSize: 20,
+                                      fontWeight: FontWeight.bold,
+                                      color: Colors.black87,
+                                    ),
                                   ),
                                   IconButton(
-                                    icon: const Icon(Icons.delete),
+                                    icon: const Icon(Icons.delete,
+                                        color: Colors.blueGrey),
                                     onPressed: () {
-                                      // Confirm deletion
+                                      // Confirm deletion dialog
                                       showDialog(
                                         context: context,
                                         builder: (BuildContext context) {
@@ -214,11 +222,12 @@ class _MarketplacePageState extends State<MarketplacePage> {
                                               TextButton(
                                                 onPressed: () {
                                                   provider.deleteMarketplace(
-                                                      marketplace
-                                                          .id!); // Implement delete method
+                                                      marketplace.id!);
                                                   Navigator.of(context).pop();
                                                 },
-                                                child: const Text('Delete'),
+                                                child: const Text('Delete',
+                                                    style: TextStyle(
+                                                        color: Colors.red)),
                                               ),
                                             ],
                                           );
@@ -229,43 +238,97 @@ class _MarketplacePageState extends State<MarketplacePage> {
                                 ],
                               ),
                               const SizedBox(height: 8),
-                              Column(
-                                crossAxisAlignment: CrossAxisAlignment.start,
+
+                              // Products within the marketplace
+                              Row(
+                                mainAxisAlignment: MainAxisAlignment.start,
                                 children: marketplace.skuMap.map((skuMap) {
                                   final product = skuMap.product;
+
+                                  // Fetch the product image if it exists
+                                  final imageUrl =
+                                      (product?.images as List<dynamic>?)
+                                                  ?.isNotEmpty ==
+                                              true
+                                          ? product!.images![0]
+                                          : null;
+
                                   return Padding(
-                                    padding: const EdgeInsets.only(bottom: 8.0),
-                                    child: Column(
-                                      crossAxisAlignment:
-                                          CrossAxisAlignment.start,
-                                      children: [
-                                        Text(
-                                          'SKU: ${skuMap.mktpSku}',
-                                          style: const TextStyle(
-                                            fontSize: 16,
-                                            fontWeight: FontWeight.bold,
-                                          ),
+                                    padding: const EdgeInsets.only(right: 12.0),
+                                    child: Card(
+                                      elevation: 3,
+                                      margin: const EdgeInsets.only(top: 8),
+                                      shape: RoundedRectangleBorder(
+                                        borderRadius: BorderRadius.circular(12),
+                                      ),
+                                      child: Padding(
+                                        padding: const EdgeInsets.all(12.0),
+                                        child: Row(
+                                          crossAxisAlignment:
+                                              CrossAxisAlignment.start,
+                                          children: [
+                                            // Display product image or a placeholder icon if no image is found
+                                            imageUrl != null
+                                                ? Image.network(
+                                                    imageUrl,
+                                                    width: 80,
+                                                    height: 80,
+                                                    fit: BoxFit.cover,
+                                                    errorBuilder: (context,
+                                                            error,
+                                                            stackTrace) =>
+                                                        const Icon(Icons.image,
+                                                            size: 80,
+                                                            color: Colors.grey),
+                                                  )
+                                                : const Icon(Icons.image,
+                                                    size: 80,
+                                                    color: Colors.grey),
+
+                                            const SizedBox(width: 12),
+                                            Column(
+                                              crossAxisAlignment:
+                                                  CrossAxisAlignment.start,
+                                              children: [
+                                                Text(
+                                                  'SKU: ${skuMap.mktpSku}',
+                                                  style: const TextStyle(
+                                                    fontSize: 16,
+                                                    fontWeight: FontWeight.bold,
+                                                    color: Colors.black87,
+                                                  ),
+                                                ),
+                                                const SizedBox(height: 8),
+                                                Text(
+                                                  'Product Name: ${product?.displayName ?? 'Unknown'}',
+                                                  style: TextStyle(
+                                                    fontSize: 16,
+                                                    color: product != null
+                                                        ? Colors.black87
+                                                        : Colors.grey,
+                                                  ),
+                                                ),
+                                                const SizedBox(height: 4),
+                                                Text(
+                                                  'Product SKU: ${product?.sku ?? 'N/A'}',
+                                                  style: TextStyle(
+                                                    fontSize: 14,
+                                                    color: product != null
+                                                        ? Colors.black54
+                                                        : Colors.grey,
+                                                  ),
+                                                ),
+                                              ],
+                                            ),
+                                          ],
                                         ),
-                                        const SizedBox(height: 4),
-                                        Text(
-                                          'Product: ${product?.displayName ?? 'Unknown'}',
-                                          style: const TextStyle(
-                                            fontSize: 16,
-                                            color: Colors.black,
-                                          ),
-                                        ),
-                                        const SizedBox(height: 4),
-                                        Text(
-                                          'Product SKU: ${product?.sku ?? 'N/A'}',
-                                          style: const TextStyle(
-                                            fontSize: 16,
-                                            color: Colors.black,
-                                          ),
-                                        ),
-                                      ],
+                                      ),
                                     ),
                                   );
                                 }).toList(),
+                              ),
+                              const SizedBox(
+                                width: 8,
                               ),
                             ],
                           ),
@@ -278,6 +341,16 @@ class _MarketplacePageState extends State<MarketplacePage> {
             ),
           ],
         ],
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {
+          // Call the method to fetch marketplaces
+          Provider.of<MarketplaceProvider>(context, listen: false)
+              .fetchMarketplaces();
+        },
+        backgroundColor: Colors.blue,
+        tooltip: 'Fetch Marketplaces',
+        child: const Icon(Icons.refresh),
       ),
     );
   }

--- a/lib/orders_page.dart
+++ b/lib/orders_page.dart
@@ -1,0 +1,506 @@
+import 'package:flutter/material.dart';
+import 'package:inventory_management/provider/orders_provider.dart';
+
+class OrdersNewPage extends StatefulWidget {
+  const OrdersNewPage({super.key});
+
+  @override
+  State<OrdersNewPage> createState() => _OrdersNewPageState();
+}
+
+class _OrdersNewPageState extends State<OrdersNewPage>
+    with SingleTickerProviderStateMixin {
+  late TabController _tabController;
+
+  final ordersProvider = OrdersProvider();
+
+  // // For managing the state of the checkboxes
+  // bool selectAll = false;
+  // List<bool> selectedOrders =
+  //     List.generate(5, (index) => false); // Assuming 5 orders for demonstration
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: 2, vsync: this); // 2 tabs
+  }
+
+  // @override
+  // void dispose() {
+  //   _tabController.dispose();
+  //   super.dispose();
+  // }
+
+  // void toggleSelectAll(bool? value) {
+  //   setState(() {
+  //     selectAll = value ?? false;
+  //     for (int i = 0; i < selectedOrders.length; i++) {
+  //       selectedOrders[i] = selectAll; // Set all to the same value
+  //     }
+  //   });
+  // }
+
+  // void toggleOrderSelection(int index, bool value) {
+  //   setState(() {
+  //     selectedOrders[index] = value; // Update individual order selection
+  //     selectAll = selectedOrders
+  //         .every((selected) => selected); // Check if all are selected
+  //   });
+  // }
+
+  // // Function to format date manually
+  // String formatDate(DateTime date) {
+  //   String year = date.year.toString();
+  //   String month = date.month.toString().padLeft(2, '0');
+  //   String day = date.day.toString().padLeft(2, '0');
+
+  //   return '$year-$month-$day'; // Format: YYYY-MM-DD
+  // }
+
+  @override
+  Widget build(BuildContext context) {
+    DateTime hardcodedDate = DateTime(2024, 9, 25);
+
+    return Scaffold(
+      appBar: AppBar(
+        bottom: PreferredSize(
+          preferredSize: const Size.fromHeight(80.0),
+          child: Column(
+            children: [
+              // A row with Filter, Sort by dropdown, and Search bar
+              Container(
+                color: Colors.blue,
+                padding: const EdgeInsets.all(8.0),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.start,
+                  children: [
+                    ElevatedButton(
+                      onPressed: () {
+                        // Implement filter logic here
+                      },
+                      style: ElevatedButton.styleFrom(
+                          backgroundColor: Colors.white),
+                      child: const Text('Filter',
+                          style: TextStyle(color: Colors.black)),
+                    ),
+                    const SizedBox(width: 10),
+                    DropdownButton<String>(
+                      value: 'Sort by',
+                      items: const [
+                        DropdownMenuItem(
+                            value: 'Sort by', child: Text('Sort by')),
+                        DropdownMenuItem(value: 'Date', child: Text('Date')),
+                        DropdownMenuItem(
+                            value: 'Amount', child: Text('Amount')),
+                      ],
+                      onChanged: (value) {
+                        // Implement sorting logic here
+                      },
+                    ),
+                    const Spacer(),
+                    Container(
+                      width: 500,
+                      height: 40,
+                      decoration: BoxDecoration(
+                        color: Colors.white,
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      child: const TextField(
+                        textAlignVertical: TextAlignVertical.center,
+                        decoration: InputDecoration(
+                          hintText: 'Search Orders',
+                          border: InputBorder.none,
+                          contentPadding: EdgeInsets.symmetric(horizontal: 8),
+                          prefixIcon: Icon(Icons.search),
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              TabBar(
+                tabAlignment: TabAlignment.start,
+                isScrollable: true,
+                indicatorSize: TabBarIndicatorSize.tab,
+                controller: _tabController,
+                tabs: const [
+                  Tab(
+                    child: Align(
+                      alignment: Alignment.centerLeft,
+                      child: Text(
+                        'Ready To Confirm',
+                        style: TextStyle(
+                          fontSize: 16,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                    ),
+                  ),
+                  Tab(
+                    child: Align(
+                      alignment: Alignment.centerLeft,
+                      child: Text(
+                        'Failed Orders',
+                        style: TextStyle(
+                          fontSize: 16,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+                indicatorColor: Colors.blue,
+                labelColor: Colors.black,
+                unselectedLabelColor: Colors.black,
+              ),
+            ],
+          ),
+        ),
+      ),
+      body: TabBarView(
+        controller: _tabController,
+        children: [
+          // Content for "Ready to Confirm"
+          buildOrdersList(hardcodedDate, false),
+          // Content for "Failed Orders"
+          buildOrdersList(hardcodedDate, true),
+        ],
+      ),
+    );
+  }
+}
+
+Widget buildOrdersList(DateTime hardcodedDate, bool showConfirmedButton) {
+  final ordersProvider = OrdersProvider();
+  return Column(
+    children: [
+      // Row showing selected orders and action buttons
+      Padding(
+        padding: const EdgeInsets.all(8.0),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.start,
+          children: [
+            Text(
+              '${ordersProvider.selectedOrders.where((selected) => selected).length} orders selected',
+              style: const TextStyle(fontSize: 16),
+            ),
+            const SizedBox(
+              width: 50,
+            ),
+            ElevatedButton.icon(
+              onPressed: () {
+                // Implement "Print Picklist" functionality here
+              },
+              icon: const Icon(Icons.print, color: Colors.white),
+              label: const Text('Print Picklist',
+                  style: TextStyle(color: Colors.white)), // Button text
+              style: ElevatedButton.styleFrom(
+                backgroundColor: Colors.blue,
+              ),
+            ),
+            const SizedBox(
+              width: 30,
+            ),
+            ElevatedButton.icon(
+              onPressed: () {
+                // Implement "Print Picklist" functionality here
+              },
+              icon: const Icon(Icons.print, color: Colors.white), // Print icon
+              label: const Text('Print Pickingslip',
+                  style: TextStyle(color: Colors.white)),
+              style: ElevatedButton.styleFrom(
+                backgroundColor: Colors.blue,
+              ),
+            ),
+            const Spacer(),
+            if (showConfirmedButton) ...[
+              ElevatedButton(
+                onPressed: () {
+                  // Implement "Print Picklist" functionality here
+                },
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: Colors.blue,
+                ),
+                child: const Text('Confirmed',
+                    style: TextStyle(color: Colors.white)),
+              ),
+            ],
+          ],
+        ),
+      ),
+      // Header for "Ready to Confirm" or "Failed Orders"
+      Padding(
+        padding: const EdgeInsets.all(8.0),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Row(
+              children: [
+                Checkbox(
+                  value: ordersProvider.selectAll,
+                  onChanged: ordersProvider.toggleSelectAll,
+                ),
+                const Text('Select All'),
+              ],
+            ),
+            const Row(
+              children: [
+                Text(
+                  'Order ID: ',
+                  style: TextStyle(fontWeight: FontWeight.bold),
+                ),
+                Text('order id 1'),
+              ],
+            ),
+            Row(
+              children: [
+                const Text(
+                  'Date:',
+                  style: TextStyle(fontWeight: FontWeight.bold),
+                ),
+                const SizedBox(width: 5),
+                Text(ordersProvider.formatDate(hardcodedDate)),
+              ],
+            ),
+            const Row(
+              children: [
+                Text(
+                  'Total Amount: ',
+                  style: TextStyle(fontWeight: FontWeight.bold),
+                ),
+                Text('\$1200'),
+              ],
+            ),
+          ],
+        ),
+      ),
+
+      Expanded(
+        child: ListView.builder(
+          itemCount: ordersProvider.selectedOrders.length,
+          itemBuilder: (context, index) {
+            return Card(
+              color: Colors.white,
+              margin: const EdgeInsets.all(8.0),
+              child: Padding(
+                padding: const EdgeInsets.all(8.0),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Checkbox(
+                      value: ordersProvider.selectedOrders[index],
+                      onChanged: (value) => ordersProvider.toggleOrderSelection(
+                          index, value ?? false),
+                    ),
+                    Container(
+                      width: 270,
+                      child: const Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          // Replace with actual image URL or Asset
+                          // Image.network('https://via.placeholder.com/50',
+                          //     height: 50, width: 50),
+
+                          Icon(
+                            Icons.image,
+                            size: 200,
+                            color: Colors.blueGrey,
+                          ),
+                          Text(
+                            'Nemotude Plus (Bio Pesticides verticillium chalamydosporium 1% WP)',
+                            softWrap: true,
+                            maxLines: 3,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                          SizedBox(
+                            height: 20,
+                          ),
+                        ],
+                      ),
+                    ),
+                    Column(
+                      mainAxisAlignment: MainAxisAlignment.start,
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        const SizedBox(
+                          height: 20,
+                        ),
+                        const Row(
+                          children: [
+                            Text(
+                              'SKU: ',
+                              style: TextStyle(fontWeight: FontWeight.bold),
+                            ),
+                            Text('123456'),
+                          ],
+                        ),
+                        const SizedBox(height: 20),
+                        const Row(
+                          children: [
+                            Text(
+                              'Quality: ',
+                              style: TextStyle(fontWeight: FontWeight.bold),
+                            ),
+                            Text(''),
+                          ],
+                        ),
+                        const SizedBox(height: 20),
+                        const Row(
+                          children: [
+                            Text(
+                              'Brand: ',
+                              style: TextStyle(fontWeight: FontWeight.bold),
+                            ),
+                            Text('BrandName'),
+                          ],
+                        ),
+                        const SizedBox(height: 20),
+                        Row(
+                          children: [
+                            const Text(
+                              'Order Item ID: ',
+                              style: TextStyle(fontWeight: FontWeight.bold),
+                            ),
+                            Text('item${index + 1}'),
+                          ],
+                        ),
+                      ],
+                    ),
+                    const Column(
+                      mainAxisAlignment: MainAxisAlignment.start,
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        SizedBox(
+                          height: 20,
+                        ),
+                        Row(
+                          children: [
+                            Text(
+                              'Total MRP: ',
+                              style: TextStyle(fontWeight: FontWeight.bold),
+                            ),
+                            Text('\$1500'),
+                          ],
+                        ),
+                        SizedBox(height: 20),
+                        Row(
+                          children: [
+                            Text(
+                              'Selling Price: ',
+                              style: TextStyle(fontWeight: FontWeight.bold),
+                            ),
+                            Text('\$1200'),
+                          ],
+                        ),
+                        SizedBox(height: 20),
+                        Row(
+                          children: [
+                            Text(
+                              'Payment Mode: ',
+                              style: TextStyle(fontWeight: FontWeight.bold),
+                            ),
+                            Text('Credit Card'),
+                          ],
+                        ),
+                        SizedBox(height: 20),
+                        Row(
+                          children: [
+                            Text(
+                              'Shipping Method: ',
+                              style: TextStyle(fontWeight: FontWeight.bold),
+                            ),
+                            Text(''),
+                          ],
+                        ),
+                        SizedBox(height: 20),
+                        Row(
+                          children: [
+                            Text(
+                              'Shipping Mode: ',
+                              style: TextStyle(fontWeight: FontWeight.bold),
+                            ),
+                            Text(''),
+                          ],
+                        ),
+                        SizedBox(height: 20),
+                        Row(
+                          children: [
+                            Text(
+                              'Payment Status: ',
+                              style: TextStyle(fontWeight: FontWeight.bold),
+                            ),
+                            Text(''),
+                          ],
+                        ),
+                      ],
+                    ),
+                    Column(
+                      mainAxisAlignment: MainAxisAlignment.start,
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        const SizedBox(
+                          height: 20,
+                        ),
+                        Row(
+                          children: [
+                            const Text(
+                              'Order Date: ',
+                              style: TextStyle(fontWeight: FontWeight.bold),
+                            ),
+                            Text(ordersProvider.formatDate(hardcodedDate)),
+                          ],
+                        ),
+                        const SizedBox(height: 20),
+                        Row(
+                          children: [
+                            const Text(
+                              'Import Date: ',
+                              style: TextStyle(fontWeight: FontWeight.bold),
+                            ),
+                            Text(ordersProvider.formatDate(hardcodedDate)),
+                          ],
+                        ),
+                        const SizedBox(height: 20),
+                        const Row(
+                          children: [
+                            Text(
+                              'TAT: ',
+                              style: TextStyle(fontWeight: FontWeight.bold),
+                            ),
+                            Text(''),
+                          ],
+                        ),
+                        const SizedBox(height: 20),
+                        Row(
+                          children: [
+                            const Text(
+                              'QC Confirmation Date: ',
+                              style: TextStyle(fontWeight: FontWeight.bold),
+                            ),
+                            Text(ordersProvider.formatDate(hardcodedDate)),
+                          ],
+                        ),
+                        const SizedBox(height: 20),
+                        const Row(
+                          children: [
+                            Text(
+                              'Inventory Assigned: ',
+                              style: TextStyle(fontWeight: FontWeight.bold),
+                            ),
+                            Text('Yes'),
+                          ],
+                        ),
+                      ],
+                    )
+                  ],
+                ),
+              ),
+            );
+          },
+        ),
+      ),
+    ],
+  );
+}

--- a/lib/packer_page.dart
+++ b/lib/packer_page.dart
@@ -1,0 +1,341 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:inventory_management/Custom-Files/colors.dart';
+import 'package:inventory_management/provider/packer_provider.dart';
+
+class PackerPage extends StatefulWidget {
+  const PackerPage({super.key});
+
+  @override
+  State<PackerPage> createState() => _PackerPageState();
+}
+
+class _PackerPageState extends State<PackerPage> {
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<PackerProvider>(
+      builder: (context, packerProvider, child) {
+        // Fixed variable name to pickerProvider
+        return Scaffold(
+          body: Column(
+            children: [
+              // Display number of selected products
+              Padding(
+                padding: const EdgeInsets.all(8.0),
+                child: Text(
+                  'Selected Orders: ${packerProvider.selectedCount}',
+                  style: const TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ),
+
+              // Table with horizontal scroll
+              Expanded(
+                child: Container(
+                  color: AppColors.greyBackground,
+                  width: double
+                      .infinity, // Make the table take the full width of the screen
+                  padding: const EdgeInsets.symmetric(
+                      horizontal: 16.0), // Optional padding
+
+                  child: SingleChildScrollView(
+                    scrollDirection: Axis.horizontal,
+                    child: SingleChildScrollView(
+                      child: DataTable(
+                        dataRowHeight: 300,
+                        columnSpacing: MediaQuery.of(context).size.width * 0.08,
+                        columns: [
+                          const DataColumn(
+                            label: Text(
+                              'ORDERS',
+                              style: TextStyle(
+                                fontSize: 18,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                          ),
+                          const DataColumn(
+                            label: Text(
+                              'CUSTOMER DETAIL',
+                              style: TextStyle(
+                                fontSize: 18,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                          ),
+                          const DataColumn(
+                            label: Text(
+                              'DATE',
+                              style: TextStyle(
+                                fontSize: 18,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                          ),
+                          const DataColumn(
+                            label: Text(
+                              'TOTAL',
+                              style: TextStyle(
+                                fontSize: 18,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                          ),
+                          const DataColumn(
+                            label: Text(
+                              'BOX SIZE',
+                              style: TextStyle(
+                                fontSize: 18,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                          ),
+                          // DataColumn with checkbox to select/deselect all products
+                          DataColumn(
+                            label: Row(
+                              children: [
+                                Transform.scale(
+                                  scale: 1,
+                                  child: Checkbox(
+                                    value: packerProvider.selectAll,
+                                    onChanged: (bool? value) {
+                                      packerProvider
+                                          .toggleSelectAll(value ?? false);
+                                    },
+                                    activeColor: Colors
+                                        .blue, // Customize the active color
+                                    checkColor: Colors
+                                        .white, // Customize the check mark color
+                                    side: const BorderSide(
+                                        color: Colors
+                                            .blue), // Customize the border color
+                                    shape: RoundedRectangleBorder(
+                                      borderRadius: BorderRadius.circular(
+                                          4), // Customize the border radius
+                                    ),
+                                  ),
+                                ),
+                                const Text('Select All'),
+                              ],
+                            ),
+                          ),
+                        ],
+                        rows: List<DataRow>.generate(
+                          packerProvider.selectedProducts.length,
+                          (index) => DataRow(
+                            selected: packerProvider.selectedProducts[index],
+                            cells: [
+                              // Product Image and Name in one cell
+                              DataCell(
+                                SizedBox(
+                                  width: 556,
+                                  child: Padding(
+                                    padding: const EdgeInsets.all(4.0),
+                                    child: Column(
+                                      crossAxisAlignment:
+                                          CrossAxisAlignment.start,
+                                      children: [
+                                        // Display the Order ID
+                                        Text(
+                                          'ORDER ID: KSK-2599${index + 1}',
+                                          style: const TextStyle(
+                                              fontWeight: FontWeight.bold,
+                                              fontSize: 20,
+                                              color: Colors.blue),
+                                        ),
+
+                                        const SizedBox(height: 10),
+
+                                        const Row(
+                                          crossAxisAlignment:
+                                              CrossAxisAlignment.start,
+                                          children: [
+                                            SizedBox(width: 10),
+                                            SizedBox(
+                                              width: 430,
+                                              child: Column(
+                                                children: [
+                                                  // Product 1 Information
+                                                  Text(
+                                                    'Nemotude Plus (Bio Pesticides verticillium chalamydosporium 1% WP)',
+                                                    style:
+                                                        TextStyle(fontSize: 16),
+                                                    softWrap:
+                                                        true, // Enable text wrapping
+                                                    maxLines:
+                                                        3, // Adjust max lines if needed
+                                                    overflow:
+                                                        TextOverflow.ellipsis,
+                                                  ),
+                                                  SizedBox(height: 4),
+
+                                                  Row(
+                                                    children: [
+                                                      Text(
+                                                        'SKU : k-5560 ',
+                                                        style: TextStyle(
+                                                            fontSize: 14,
+                                                            fontWeight:
+                                                                FontWeight
+                                                                    .bold),
+                                                      ),
+                                                      SizedBox(width: 150),
+                                                      Text(
+                                                        'Quality : 10 ',
+                                                        style: TextStyle(
+                                                            fontSize: 14,
+                                                            fontWeight:
+                                                                FontWeight
+                                                                    .bold),
+                                                      ),
+                                                    ],
+                                                  ),
+                                                  SizedBox(height: 10),
+                                                ],
+                                              ),
+                                            ),
+                                          ],
+                                        ),
+                                        const Divider(color: Colors.grey),
+                                        const Row(
+                                          children: [
+                                            SizedBox(width: 10),
+                                            SizedBox(
+                                              width: 430,
+                                              child: Column(
+                                                children: [
+                                                  // Product 1 Information
+                                                  Text(
+                                                    'Motude Plus (Bio Pesticides verticillium chalamydosporium 1% WP)',
+                                                    style:
+                                                        TextStyle(fontSize: 16),
+                                                    softWrap:
+                                                        true, // Enable text wrapping
+                                                    maxLines:
+                                                        3, // Adjust max lines if needed
+                                                    overflow:
+                                                        TextOverflow.ellipsis,
+                                                  ),
+                                                  SizedBox(height: 4),
+                                                  Row(
+                                                    children: [
+                                                      Text(
+                                                        'SKU : k-9560 ',
+                                                        style: TextStyle(
+                                                            fontSize: 14,
+                                                            fontWeight:
+                                                                FontWeight
+                                                                    .bold),
+                                                      ),
+                                                      SizedBox(width: 150),
+                                                      Text(
+                                                        'Quality : 04 ',
+                                                        style: TextStyle(
+                                                            fontSize: 14,
+                                                            fontWeight:
+                                                                FontWeight
+                                                                    .bold),
+                                                      ),
+                                                    ],
+                                                  ),
+                                                  SizedBox(height: 10),
+                                                ],
+                                              ),
+                                            ),
+                                          ],
+                                        ),
+                                      ],
+                                    ),
+                                  ),
+                                ),
+                              ),
+                              // Delivery price (INR)
+                              const DataCell(
+                                Column(
+                                  mainAxisAlignment: MainAxisAlignment.center,
+                                  children: [
+                                    Text(
+                                      'Deependra Singh',
+                                      style: TextStyle(fontSize: 18),
+                                      overflow: TextOverflow.visible,
+                                      softWrap: true,
+                                    ),
+                                    Text(
+                                      '8758568384',
+                                      style: TextStyle(fontSize: 18),
+                                      overflow: TextOverflow.visible,
+                                      softWrap: true,
+                                    ),
+                                  ],
+                                ),
+                              ),
+
+                              // Shiprocket price (INR)
+                              const DataCell(
+                                Text(
+                                  '12/02/2020',
+                                  style: TextStyle(fontSize: 18),
+                                  overflow: TextOverflow.visible,
+                                  softWrap: true,
+                                ),
+                              ),
+                              const DataCell(
+                                Text(
+                                  '\$1200',
+                                  style: TextStyle(fontSize: 18),
+                                  overflow: TextOverflow.visible,
+                                  softWrap: true,
+                                ),
+                              ),
+
+                              DataCell(
+                                Text(
+                                  'Box Size ${index + 1}',
+                                  style: const TextStyle(fontSize: 18),
+                                  overflow: TextOverflow.visible,
+                                  softWrap: true,
+                                ),
+                              ),
+
+                              // Checkbox for each row
+                              DataCell(
+                                Transform.scale(
+                                  scale: 1,
+                                  child: Checkbox(
+                                    value:
+                                        packerProvider.selectedProducts[index],
+                                    onChanged: (bool? value) {
+                                      packerProvider.toggleProductSelection(
+                                          index, value ?? false);
+                                    },
+                                    activeColor: Colors
+                                        .blue, // Customize the active color
+                                    checkColor: Colors
+                                        .white, // Customize the check mark color
+                                    side: const BorderSide(
+                                        color: Colors
+                                            .blue), // Customize the border color
+                                    shape: RoundedRectangleBorder(
+                                      borderRadius: BorderRadius.circular(
+                                          4), // Customize the border radius
+                                    ),
+                                  ),
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/picker_page.dart
+++ b/lib/picker_page.dart
@@ -1,0 +1,323 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:inventory_management/Custom-Files/colors.dart';
+import 'package:inventory_management/provider/picker_provider.dart';
+
+class PickerPage extends StatefulWidget {
+  const PickerPage({super.key});
+
+  @override
+  State<PickerPage> createState() => _PickerPageState();
+}
+
+class _PickerPageState extends State<PickerPage> {
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<PickerProvider>(
+      builder: (context, pickerProvider, child) {
+        // Fixed variable name to pickerProvider
+        return Scaffold(
+          body: Column(
+            children: [
+              // Display number of selected products
+              Padding(
+                padding: const EdgeInsets.all(8.0),
+                child: Text(
+                  'Selected Orders: ${pickerProvider.selectedCount}',
+                  style: const TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ),
+
+              // Table with horizontal scroll
+              Expanded(
+                child: Container(
+                  color: AppColors.greyBackground,
+                  width: double
+                      .infinity, // Make the table take the full width of the screen
+                  padding: const EdgeInsets.symmetric(
+                      horizontal: 16.0), // Optional padding
+
+                  child: SingleChildScrollView(
+                    scrollDirection: Axis.horizontal,
+                    child: SingleChildScrollView(
+                      child: DataTable(
+                        dataRowHeight: 300,
+                        columnSpacing: MediaQuery.of(context).size.width * 0.08,
+                        columns: [
+                          const DataColumn(
+                            label: Text(
+                              'ORDERS',
+                              style: TextStyle(
+                                fontSize: 18,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                          ),
+                          const DataColumn(
+                            label: Text(
+                              'CUSTOMER DETAIL',
+                              style: TextStyle(
+                                fontSize: 18,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                          ),
+                          const DataColumn(
+                            label: Text(
+                              'DATE',
+                              style: TextStyle(
+                                fontSize: 18,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                          ),
+                          const DataColumn(
+                            label: Text(
+                              'TOTAL',
+                              style: TextStyle(
+                                fontSize: 18,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                          ),
+                          // DataColumn with checkbox to select/deselect all products
+                          DataColumn(
+                            label: Row(
+                              children: [
+                                Transform.scale(
+                                  scale: 1,
+                                  child: Checkbox(
+                                    value: pickerProvider.selectAll,
+                                    onChanged: (bool? value) {
+                                      pickerProvider
+                                          .toggleSelectAll(value ?? false);
+                                    },
+                                    activeColor: Colors
+                                        .blue, // Customize the active color
+                                    checkColor: Colors
+                                        .white, // Customize the check mark color
+                                    side: const BorderSide(
+                                        color: Colors
+                                            .blue), // Customize the border color
+                                    shape: RoundedRectangleBorder(
+                                      borderRadius: BorderRadius.circular(
+                                          4), // Customize the border radius
+                                    ),
+                                  ),
+                                ),
+                                const Text('Select All'),
+                              ],
+                            ),
+                          ),
+                        ],
+                        rows: List<DataRow>.generate(
+                          pickerProvider.selectedProducts.length,
+                          (index) => DataRow(
+                            selected: pickerProvider.selectedProducts[index],
+                            cells: [
+                              // Product Image and Name in one cell
+                              DataCell(
+                                SizedBox(
+                                  width: 556,
+                                  child: Padding(
+                                    padding: const EdgeInsets.all(4.0),
+                                    child: Column(
+                                      crossAxisAlignment:
+                                          CrossAxisAlignment.start,
+                                      children: [
+                                        // Display the Order ID
+                                        Text(
+                                          'ORDER ID: KSK-2599${index + 1}',
+                                          style: const TextStyle(
+                                              fontWeight: FontWeight.bold,
+                                              fontSize: 20,
+                                              color: Colors.blue),
+                                        ),
+
+                                        const SizedBox(height: 10),
+
+                                        const Row(
+                                          crossAxisAlignment:
+                                              CrossAxisAlignment.start,
+                                          children: [
+                                            SizedBox(width: 10),
+                                            SizedBox(
+                                              width: 430,
+                                              child: Column(
+                                                children: [
+                                                  // Product 1 Information
+                                                  Text(
+                                                    'Nemotude Plus (Bio Pesticides verticillium chalamydosporium 1% WP)',
+                                                    style:
+                                                        TextStyle(fontSize: 16),
+                                                    softWrap:
+                                                        true, // Enable text wrapping
+                                                    maxLines:
+                                                        3, // Adjust max lines if needed
+                                                    overflow:
+                                                        TextOverflow.ellipsis,
+                                                  ),
+                                                  SizedBox(height: 4),
+
+                                                  Row(
+                                                    children: [
+                                                      Text(
+                                                        'SKU : k-5560 ',
+                                                        style: TextStyle(
+                                                            fontSize: 14,
+                                                            fontWeight:
+                                                                FontWeight
+                                                                    .bold),
+                                                      ),
+                                                      SizedBox(width: 150),
+                                                      Text(
+                                                        'Quality : 10 ',
+                                                        style: TextStyle(
+                                                            fontSize: 14,
+                                                            fontWeight:
+                                                                FontWeight
+                                                                    .bold),
+                                                      ),
+                                                    ],
+                                                  ),
+                                                  SizedBox(height: 10),
+                                                ],
+                                              ),
+                                            ),
+                                          ],
+                                        ),
+                                        const Divider(color: Colors.grey),
+                                        const Row(
+                                          children: [
+                                            SizedBox(width: 10),
+                                            SizedBox(
+                                              width: 430,
+                                              child: Column(
+                                                children: [
+                                                  // Product 1 Information
+                                                  Text(
+                                                    'Motude Plus (Bio Pesticides verticillium chalamydosporium 1% WP)',
+                                                    style:
+                                                        TextStyle(fontSize: 16),
+                                                    softWrap:
+                                                        true, // Enable text wrapping
+                                                    maxLines:
+                                                        3, // Adjust max lines if needed
+                                                    overflow:
+                                                        TextOverflow.ellipsis,
+                                                  ),
+                                                  SizedBox(height: 4),
+                                                  Row(
+                                                    children: [
+                                                      Text(
+                                                        'SKU : k-9560 ',
+                                                        style: TextStyle(
+                                                            fontSize: 14,
+                                                            fontWeight:
+                                                                FontWeight
+                                                                    .bold),
+                                                      ),
+                                                      SizedBox(width: 150),
+                                                      Text(
+                                                        'Quality : 04 ',
+                                                        style: TextStyle(
+                                                            fontSize: 14,
+                                                            fontWeight:
+                                                                FontWeight
+                                                                    .bold),
+                                                      ),
+                                                    ],
+                                                  ),
+                                                  SizedBox(height: 10),
+                                                ],
+                                              ),
+                                            ),
+                                          ],
+                                        ),
+                                      ],
+                                    ),
+                                  ),
+                                ),
+                              ),
+                              // Delivery price (INR)
+                              const DataCell(
+                                Column(
+                                  mainAxisAlignment: MainAxisAlignment.center,
+                                  children: [
+                                    Text(
+                                      'Deependra Singh',
+                                      style: TextStyle(fontSize: 18),
+                                      overflow: TextOverflow.visible,
+                                      softWrap: true,
+                                    ),
+                                    Text(
+                                      '8758568384',
+                                      style: TextStyle(fontSize: 18),
+                                      overflow: TextOverflow.visible,
+                                      softWrap: true,
+                                    ),
+                                  ],
+                                ),
+                              ),
+
+                              // Shiprocket price (INR)
+                              const DataCell(
+                                Text(
+                                  '12/02/2020',
+                                  style: TextStyle(fontSize: 18),
+                                  overflow: TextOverflow.visible,
+                                  softWrap: true,
+                                ),
+                              ),
+                              const DataCell(
+                                Text(
+                                  '\$1200',
+                                  style: TextStyle(fontSize: 18),
+                                  overflow: TextOverflow.visible,
+                                  softWrap: true,
+                                ),
+                              ),
+
+                              // Checkbox for each row
+                              DataCell(
+                                Transform.scale(
+                                  scale: 1,
+                                  child: Checkbox(
+                                    value:
+                                        pickerProvider.selectedProducts[index],
+                                    onChanged: (bool? value) {
+                                      pickerProvider.toggleProductSelection(
+                                          index, value ?? false);
+                                    },
+                                    activeColor: Colors
+                                        .blue, // Customize the active color
+                                    checkColor: Colors
+                                        .white, // Customize the check mark color
+                                    side: const BorderSide(
+                                        color: Colors
+                                            .blue), // Customize the border color
+                                    shape: RoundedRectangleBorder(
+                                      borderRadius: BorderRadius.circular(
+                                          4), // Customize the border radius
+                                    ),
+                                  ),
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/provider/checker_provider.dart
+++ b/lib/provider/checker_provider.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+
+class CheckerProvider with ChangeNotifier {
+  bool _selectAll = false;
+  List<bool> _selectedProducts = List<bool>.generate(10, (index) => false);
+
+  bool get selectAll => _selectAll;
+  List<bool> get selectedProducts => _selectedProducts;
+
+  int get selectedCount =>
+      _selectedProducts.where((isSelected) => isSelected).length;
+
+  void toggleSelectAll(bool value) {
+    _selectAll = value;
+    _selectedProducts =
+        List<bool>.generate(_selectedProducts.length, (index) => _selectAll);
+    notifyListeners();
+  }
+
+  void toggleProductSelection(int index, bool value) {
+    _selectedProducts[index] = value;
+    // If any product is deselected, uncheck the "Select All" box
+    if (!_selectedProducts.contains(true)) {
+      _selectAll = false;
+    }
+    notifyListeners();
+  }
+}

--- a/lib/provider/combo_provider.dart
+++ b/lib/provider/combo_provider.dart
@@ -2,7 +2,6 @@ import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:inventory_management/model/combo_model.dart';
 import 'package:inventory_management/Api/combo_api.dart';
-import 'package:multi_dropdown/multi_dropdown.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/foundation.dart';
@@ -11,11 +10,15 @@ class ComboProvider with ChangeNotifier {
   Combo? _combo;
   bool _isFormVisible = false;
   List<Combo> _comboList = [];
-  List<DropdownItem<String>> _items = [];
-  List<DropdownItem<String>> get item=>_items;
+
   List<Product> _products = [];
   List<Product> _selectedProducts = [];
   bool _loading = false;
+
+  // Pagination state variables
+  int _currentPage = 1; // Track current page
+  int _totalPages = 1; // Track total pages (comes from API)
+  int _limit = 10; // Default limit per page (you can change this as needed)
 
   Combo? get combo => _combo;
   bool get isFormVisible => _isFormVisible;
@@ -32,7 +35,7 @@ class ComboProvider with ChangeNotifier {
   List<String> imageNames = [];
 
   ComboProvider() {
-    _loadCombos();
+    fetchCombos();
   }
 
   // Toggles the visibility of the combo creation form
@@ -41,18 +44,9 @@ class ComboProvider with ChangeNotifier {
     notifyListeners();
   }
 
+  // Sets the current combo and notifies listeners
   void setCombo(Combo combo) {
     _combo = combo;
-    notifyListeners();
-  }
-
-
-  // Sets the current combo and notifies listeners
-  void addItem(String label,String value) {
-    // _combo = combo;
-    _items.add(DropdownItem<String>(label: label, value: value));
-
-    print("item len  ${_items.length}");
     notifyListeners();
   }
 
@@ -93,11 +87,12 @@ class ComboProvider with ChangeNotifier {
     }
   }
 
-  Future<void> fetchCombos() async {
+  Future<void> fetchCombos({int page = 1, int limit = 10}) async {
     _loading = true;
     notifyListeners();
     try {
-      _combosList = await comboApi.getCombos();
+      _combosList = await comboApi.getCombos(page: page, limit: limit);
+      //print("comboProvider.combosList : $_combosList");
     } catch (e) {
       print('Error fetching combos: $e');
     }
@@ -132,29 +127,35 @@ class ComboProvider with ChangeNotifier {
     notifyListeners();
   }
 
-  // fetch products
   Future<void> fetchProducts() async {
     _loading = true;
-    notifyListeners();
+    notifyListeners(); // Notify listeners to show loading state
     try {
       final api = ComboApi();
-      final productList = await api.getAllProducts();
+
+      // Fetch the full response (which contains the 'products' array)
+      final response = await api.getAllProducts();
+
+      // Extract the 'products' array from the response
+      final productList = response['products'];
+
+      // Print raw productList for debugging
+      //print("productList in provider: $productList");
+
+      // Map the 'products' array into the Product model list
       _products =
           productList.map<Product>((json) => Product.fromJson(json)).toList();
 
-      /*
-    // Print the IDs of the fetched products
-    print('Fetched product IDs:');
-    for (var product in _products) {
-    print(product.id); // Ensure 'id' is a valid field in your Product class
+      // Print the mapped products for debugging
+      //print("products in provider: $_products");
+    } catch (e, stacktrace) {
+      // Log error details
+      print('Error fetching products: $e');
+      print('Stacktrace: $stacktrace');
+    } finally {
+      _loading = false; // Stop loading once the process is done
+      notifyListeners(); // Notify listeners to hide loading state and update UI
     }
-      */
-
-    } catch (e) {
-      // Handle errors
-    }
-    _loading = false;
-    notifyListeners();
   }
 
   // void selectProducts(List<Product> products) {
@@ -162,9 +163,10 @@ class ComboProvider with ChangeNotifier {
   //   notifyListeners();
   // }
 
-    // Method to select products by IDs
+  // Method to select products by IDs
   void selectProductsByIds(List<String?> productIds) {
-    _selectedProducts = _products.where((product) => productIds.contains(product.id)).toList();
+    _selectedProducts =
+        _products.where((product) => productIds.contains(product.id)).toList();
     notifyListeners();
   }
 }

--- a/lib/provider/manifest_provider.dart
+++ b/lib/provider/manifest_provider.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+
+class ManifestProvider with ChangeNotifier {
+  bool _isB2BSelected = true;
+  bool _selectAll = false;
+  List<bool> _selectedProducts = List<bool>.generate(10, (index) => false);
+
+  bool get isB2BSelected => _isB2BSelected;
+  bool get selectAll => _selectAll;
+  List<bool> get selectedProducts => _selectedProducts;
+
+  int get selectedCount =>
+      _selectedProducts.where((isSelected) => isSelected).length;
+
+  void toggleSelection(bool isB2B) {
+    _isB2BSelected = isB2B;
+    notifyListeners();
+  }
+
+  void toggleSelectAll(bool value) {
+    _selectAll = value;
+    _selectedProducts =
+        List<bool>.generate(_selectedProducts.length, (index) => _selectAll);
+    notifyListeners();
+  }
+
+  void toggleProductSelection(int index, bool value) {
+    _selectedProducts[index] = value;
+    // If any product is deselected, uncheck the "Select All" box
+    if (!_selectedProducts.contains(true)) {
+      _selectAll = false;
+    }
+    notifyListeners();
+  }
+}

--- a/lib/provider/orders_provider.dart
+++ b/lib/provider/orders_provider.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+
+class OrdersProvider with ChangeNotifier {
+  TabController? _tabController;
+  bool _selectAll = false;
+  List<bool> _selectedOrders = List.generate(5, (index) => false);
+
+  TabController? get tabController => _tabController;
+  bool get selectAll => _selectAll; // for checkbox state
+  List<bool> get selectedOrders => _selectedOrders;
+
+  void initTabController(TickerProvider vsync, int length) {
+    _tabController = TabController(length: length, vsync: vsync);
+    notifyListeners();
+  }
+
+  void disposeTabController() {
+    _tabController?.dispose();
+  }
+
+  // toggle all checkboxes
+  void toggleSelectAll(bool? value) {
+    _selectAll = value ?? false;
+    for (int i = 0; i < _selectedOrders.length; i++) {
+      _selectedOrders[i] = _selectAll;
+    }
+    notifyListeners();
+  }
+
+  // toggle single checkbox
+  void toggleOrderSelection(int index, bool value) {
+    _selectedOrders[index] = value;
+    _selectAll = _selectedOrders.every((selected) => selected);
+    notifyListeners();
+  }
+
+  // to format date
+  String formatDate(DateTime date) {
+    String year = date.year.toString();
+    String month = date.month.toString().padLeft(2, '0');
+    String day = date.day.toString().padLeft(2, '0');
+    return '$year-$month-$day';
+  }
+}

--- a/lib/provider/packer_provider.dart
+++ b/lib/provider/packer_provider.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+
+class PackerProvider with ChangeNotifier {
+  bool _selectAll = false;
+  List<bool> _selectedProducts = List<bool>.generate(10, (index) => false);
+
+  bool get selectAll => _selectAll;
+  List<bool> get selectedProducts => _selectedProducts;
+
+  int get selectedCount =>
+      _selectedProducts.where((isSelected) => isSelected).length;
+
+  void toggleSelectAll(bool value) {
+    _selectAll = value;
+    _selectedProducts =
+        List<bool>.generate(_selectedProducts.length, (index) => _selectAll);
+    notifyListeners();
+  }
+
+  void toggleProductSelection(int index, bool value) {
+    _selectedProducts[index] = value;
+    // If any product is deselected, uncheck the "Select All" box
+    if (!_selectedProducts.contains(true)) {
+      _selectAll = false;
+    }
+    notifyListeners();
+  }
+}

--- a/lib/provider/picker_provider.dart
+++ b/lib/provider/picker_provider.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+
+class PickerProvider with ChangeNotifier {
+  bool _selectAll = false;
+  List<bool> _selectedProducts = List<bool>.generate(10, (index) => false);
+
+  bool get selectAll => _selectAll;
+  List<bool> get selectedProducts => _selectedProducts;
+
+  int get selectedCount =>
+      _selectedProducts.where((isSelected) => isSelected).length;
+
+  void toggleSelectAll(bool value) {
+    _selectAll = value;
+    _selectedProducts =
+        List<bool>.generate(_selectedProducts.length, (index) => _selectAll);
+    notifyListeners();
+  }
+
+  void toggleProductSelection(int index, bool value) {
+    _selectedProducts[index] = value;
+    // If any product is deselected, uncheck the "Select All" box
+    if (!_selectedProducts.contains(true)) {
+      _selectAll = false;
+    }
+    notifyListeners();
+  }
+}

--- a/lib/provider/racked_provider.dart
+++ b/lib/provider/racked_provider.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+
+class RackedProvider with ChangeNotifier {
+  bool _selectAll = false;
+  List<bool> _selectedProducts = List<bool>.generate(10, (index) => false);
+
+  bool get selectAll => _selectAll;
+  List<bool> get selectedProducts => _selectedProducts;
+
+  int get selectedCount =>
+      _selectedProducts.where((isSelected) => isSelected).length;
+
+  void toggleSelectAll(bool value) {
+    _selectAll = value;
+    _selectedProducts =
+        List<bool>.generate(_selectedProducts.length, (index) => _selectAll);
+    notifyListeners();
+  }
+
+  void toggleProductSelection(int index, bool value) {
+    _selectedProducts[index] = value;
+    // If any product is deselected, uncheck the "Select All" box
+    if (!_selectedProducts.contains(true)) {
+      _selectAll = false;
+    }
+    notifyListeners();
+  }
+}

--- a/lib/racked_page.dart
+++ b/lib/racked_page.dart
@@ -1,0 +1,341 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:inventory_management/Custom-Files/colors.dart';
+import 'package:inventory_management/provider/racked_provider.dart';
+
+class RackedPage extends StatefulWidget {
+  const RackedPage({super.key});
+
+  @override
+  State<RackedPage> createState() => _RackedPageState();
+}
+
+class _RackedPageState extends State<RackedPage> {
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<RackedProvider>(
+      builder: (context, rackedProvider, child) {
+        // Fixed variable name to pickerProvider
+        return Scaffold(
+          body: Column(
+            children: [
+              // Display number of selected products
+              Padding(
+                padding: const EdgeInsets.all(8.0),
+                child: Text(
+                  'Selected Orders: ${rackedProvider.selectedCount}',
+                  style: const TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ),
+
+              // Table with horizontal scroll
+              Expanded(
+                child: Container(
+                  color: AppColors.greyBackground,
+                  width: double
+                      .infinity, // Make the table take the full width of the screen
+                  padding: const EdgeInsets.symmetric(
+                      horizontal: 16.0), // Optional padding
+
+                  child: SingleChildScrollView(
+                    scrollDirection: Axis.horizontal,
+                    child: SingleChildScrollView(
+                      child: DataTable(
+                        dataRowHeight: 300,
+                        columnSpacing: MediaQuery.of(context).size.width * 0.08,
+                        columns: [
+                          const DataColumn(
+                            label: Text(
+                              'ORDERS',
+                              style: TextStyle(
+                                fontSize: 18,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                          ),
+                          const DataColumn(
+                            label: Text(
+                              'CUSTOMER DETAIL',
+                              style: TextStyle(
+                                fontSize: 18,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                          ),
+                          const DataColumn(
+                            label: Text(
+                              'DATE',
+                              style: TextStyle(
+                                fontSize: 18,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                          ),
+                          const DataColumn(
+                            label: Text(
+                              'TOTAL',
+                              style: TextStyle(
+                                fontSize: 18,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                          ),
+                          const DataColumn(
+                            label: Text(
+                              'WEIGHT',
+                              style: TextStyle(
+                                fontSize: 18,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                          ),
+                          // DataColumn with checkbox to select/deselect all products
+                          DataColumn(
+                            label: Row(
+                              children: [
+                                Transform.scale(
+                                  scale: 1,
+                                  child: Checkbox(
+                                    value: rackedProvider.selectAll,
+                                    onChanged: (bool? value) {
+                                      rackedProvider
+                                          .toggleSelectAll(value ?? false);
+                                    },
+                                    activeColor: Colors
+                                        .blue, // Customize the active color
+                                    checkColor: Colors
+                                        .white, // Customize the check mark color
+                                    side: const BorderSide(
+                                        color: Colors
+                                            .blue), // Customize the border color
+                                    shape: RoundedRectangleBorder(
+                                      borderRadius: BorderRadius.circular(
+                                          4), // Customize the border radius
+                                    ),
+                                  ),
+                                ),
+                                const Text('Select All'),
+                              ],
+                            ),
+                          ),
+                        ],
+                        rows: List<DataRow>.generate(
+                          rackedProvider.selectedProducts.length,
+                          (index) => DataRow(
+                            selected: rackedProvider.selectedProducts[index],
+                            cells: [
+                              // Product Image and Name in one cell
+                              DataCell(
+                                SizedBox(
+                                  width: 556,
+                                  child: Padding(
+                                    padding: const EdgeInsets.all(4.0),
+                                    child: Column(
+                                      crossAxisAlignment:
+                                          CrossAxisAlignment.start,
+                                      children: [
+                                        // Display the Order ID
+                                        Text(
+                                          'ORDER ID: KSK-2599${index + 1}',
+                                          style: const TextStyle(
+                                              fontWeight: FontWeight.bold,
+                                              fontSize: 20,
+                                              color: Colors.blue),
+                                        ),
+
+                                        const SizedBox(height: 10),
+
+                                        const Row(
+                                          crossAxisAlignment:
+                                              CrossAxisAlignment.start,
+                                          children: [
+                                            SizedBox(width: 10),
+                                            SizedBox(
+                                              width: 430,
+                                              child: Column(
+                                                children: [
+                                                  // Product 1 Information
+                                                  Text(
+                                                    'Nemotude Plus (Bio Pesticides verticillium chalamydosporium 1% WP)',
+                                                    style:
+                                                        TextStyle(fontSize: 16),
+                                                    softWrap:
+                                                        true, // Enable text wrapping
+                                                    maxLines:
+                                                        3, // Adjust max lines if needed
+                                                    overflow:
+                                                        TextOverflow.ellipsis,
+                                                  ),
+                                                  SizedBox(height: 4),
+
+                                                  Row(
+                                                    children: [
+                                                      Text(
+                                                        'SKU : k-5560 ',
+                                                        style: TextStyle(
+                                                            fontSize: 14,
+                                                            fontWeight:
+                                                                FontWeight
+                                                                    .bold),
+                                                      ),
+                                                      SizedBox(width: 150),
+                                                      Text(
+                                                        'Quality : 10 ',
+                                                        style: TextStyle(
+                                                            fontSize: 14,
+                                                            fontWeight:
+                                                                FontWeight
+                                                                    .bold),
+                                                      ),
+                                                    ],
+                                                  ),
+                                                  SizedBox(height: 10),
+                                                ],
+                                              ),
+                                            ),
+                                          ],
+                                        ),
+                                        const Divider(color: Colors.grey),
+                                        const Row(
+                                          children: [
+                                            SizedBox(width: 10),
+                                            SizedBox(
+                                              width: 430,
+                                              child: Column(
+                                                children: [
+                                                  // Product 1 Information
+                                                  Text(
+                                                    'Motude Plus (Bio Pesticides verticillium chalamydosporium 1% WP)',
+                                                    style:
+                                                        TextStyle(fontSize: 16),
+                                                    softWrap:
+                                                        true, // Enable text wrapping
+                                                    maxLines:
+                                                        3, // Adjust max lines if needed
+                                                    overflow:
+                                                        TextOverflow.ellipsis,
+                                                  ),
+                                                  SizedBox(height: 4),
+                                                  Row(
+                                                    children: [
+                                                      Text(
+                                                        'SKU : k-9560 ',
+                                                        style: TextStyle(
+                                                            fontSize: 14,
+                                                            fontWeight:
+                                                                FontWeight
+                                                                    .bold),
+                                                      ),
+                                                      SizedBox(width: 150),
+                                                      Text(
+                                                        'Quality : 04 ',
+                                                        style: TextStyle(
+                                                            fontSize: 14,
+                                                            fontWeight:
+                                                                FontWeight
+                                                                    .bold),
+                                                      ),
+                                                    ],
+                                                  ),
+                                                  SizedBox(height: 10),
+                                                ],
+                                              ),
+                                            ),
+                                          ],
+                                        ),
+                                      ],
+                                    ),
+                                  ),
+                                ),
+                              ),
+                              // Delivery price (INR)
+                              const DataCell(
+                                Column(
+                                  mainAxisAlignment: MainAxisAlignment.center,
+                                  children: [
+                                    Text(
+                                      'Deependra Singh',
+                                      style: TextStyle(fontSize: 18),
+                                      overflow: TextOverflow.visible,
+                                      softWrap: true,
+                                    ),
+                                    Text(
+                                      '8758568384',
+                                      style: TextStyle(fontSize: 18),
+                                      overflow: TextOverflow.visible,
+                                      softWrap: true,
+                                    ),
+                                  ],
+                                ),
+                              ),
+
+                              // Shiprocket price (INR)
+                              const DataCell(
+                                Text(
+                                  '12/02/2020',
+                                  style: TextStyle(fontSize: 18),
+                                  overflow: TextOverflow.visible,
+                                  softWrap: true,
+                                ),
+                              ),
+                              const DataCell(
+                                Text(
+                                  '\$1200',
+                                  style: TextStyle(fontSize: 18),
+                                  overflow: TextOverflow.visible,
+                                  softWrap: true,
+                                ),
+                              ),
+
+                              DataCell(
+                                Text(
+                                  'Weight ${index + 1}',
+                                  style: const TextStyle(fontSize: 18),
+                                  overflow: TextOverflow.visible,
+                                  softWrap: true,
+                                ),
+                              ),
+
+                              // Checkbox for each row
+                              DataCell(
+                                Transform.scale(
+                                  scale: 1,
+                                  child: Checkbox(
+                                    value:
+                                        rackedProvider.selectedProducts[index],
+                                    onChanged: (bool? value) {
+                                      rackedProvider.toggleProductSelection(
+                                          index, value ?? false);
+                                    },
+                                    activeColor: Colors
+                                        .blue, // Customize the active color
+                                    checkColor: Colors
+                                        .white, // Customize the check mark color
+                                    side: const BorderSide(
+                                        color: Colors
+                                            .blue), // Customize the border color
+                                    shape: RoundedRectangleBorder(
+                                      borderRadius: BorderRadius.circular(
+                                          4), // Customize the border radius
+                                    ),
+                                  ),
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
### Combo Page
This PR fixes the following in the Combo Page: 
- Product selection dropdown (concatenated labels of products with indices - to make them unique)
- Implemented pagination (added two buttons to navigate to the "previous" or "next" page)

### Orders
Created UIs for the following (along with their corresponding providers):

1. Orders (OrdersNewPage) [Older version "OrdersPage" is not removed]
2. Book (BookPage)
3. Picker (PickerPage)
4. Packer (PackerPage)
5. Checker (CheckerPage)
6. Racked (RackedPage)
7. Manifest (ManifestPage)

### Changes in main.dart and dashboard.dart:
- Added providers for above UIs (in main.dart)
- Added new drawer item under Orders in the UI with name "Orders" (in dashboard.dart)
- No changes made to previously made "Orders Page" screen.
